### PR TITLE
Added ability to use custom render function for a tooltip's content

### DIFF
--- a/atlascharts/line.js
+++ b/atlascharts/line.js
@@ -48,21 +48,24 @@ define(["d3", "d3-shape", "d3-scale", "./chart"],
 	      ticks: 10,
 	      showSeriesLabel: false,
 	      labelIndexDate: false,
-	      colorBasedOnIndex: false
-	    };
-	    const options = this.getOptions(defaults, chartOptions);
-	    // container
-	    const svg = this.createSvg(target, w, h);
+	      colorBasedOnIndex: false,
+        getTooltipBuilder: null,
+      };
+      const options = this.getOptions(defaults, chartOptions);
+      // container
+      const svg = this.createSvg(target, w, h);
 
-	    const tooltipBuilder = this.lineDefaultTooltip(
-	      options.xLabel || 'x',
-	      options.xFormat,
-	      d => d[options.xValue],
-	      options.yLabel || 'y',
-	      options.yFormat,
-	      d => d[options.yValue],
-	      d => d[options.seriesName]
-	    );
+      const tooltipBuilder = typeof options.getTooltipBuilder === 'function'
+				? options.getTooltipBuilder(options)
+				: this.lineDefaultTooltip(
+						options.xLabel || 'x',
+						options.xFormat,
+						d => d[options.xValue],
+						options.yLabel || 'y',
+						options.yFormat,
+						d => d[options.yValue],
+						d => d[options.seriesName]
+					);
 
 	    if (data.length > 0) {
 	      // convert data to multi-series format if not already formatted


### PR DESCRIPTION
Today tooltip's content in line charts can be rendered only by built-in default function. The PR adds ability to pass custom tooltip render function into a chart.

Usage example:
```
this.getTooltipBuilder = function(options) {
          return (d) => {
            let tipText = '';
            tipText += `Period: ${options.xFormat(d.xValue)} - ${options.xFormat(d.periodEnd)}</br>`;
            tipText += `${options.yLabel}: ${BaseCostUtilReport.formatFullNumber(d.yValue)}`;
            return tipText;
          };
        };
```


Results:
![image](https://user-images.githubusercontent.com/10010071/39058511-b7d7b31a-44c4-11e8-803a-7e414a859a21.png)

