### PR TITLE
Handle target as a string.

### DIFF
--- a/atlascharts/line.js
+++ b/atlascharts/line.js
@@ -101,6 +101,10 @@ define(["d3", "./chart"],
 
     render(data, target, w, h, chartOptions) {
 
+      if (typeof target == "string") {
+        target = document.querySelector(target);
+      }
+      
       if (!target.doResize){
         target.doResize = Line.debounce(() => {
           if (target.parentElement == null) {

--- a/examples/lineplot.html
+++ b/examples/lineplot.html
@@ -47,7 +47,7 @@
 		requirejs(['atlascharts/line'], function(line) {
 			var cartData;
 			var lineplot = new line();
-			var target = document.querySelector('#plot');
+			var target = '#plot';
 			var seriesColors = { "Ascending": "#00ff00", "Descending": "#ff0000", "Stable": "#0000ff" }
 
 			function refreshPlot() {

--- a/examples/lineplot_optimized.html
+++ b/examples/lineplot_optimized.html
@@ -48,7 +48,7 @@
 			var cartData;
 			// works differently with bundles: the entire module was required(), so line is contained by the charts module.
 			var lineplot = new charts.line();
-			var target = document.querySelector('#plot');
+			var target = '#plot';
 
 			function refreshPlot() {
 				chartData = JSON.parse(document.querySelector("#chartData").value);


### PR DESCRIPTION
Updated examples to set target as a selector instead of selecting the element (both cases work).